### PR TITLE
Limit log size

### DIFF
--- a/kong/build-docker.sh
+++ b/kong/build-docker.sh
@@ -1,5 +1,5 @@
 KONG_VERSION=2.4.1-alpine
-LOGGER_VERSION=0.1.3
+LOGGER_VERSION=0.1.4
 
 ./build-plugin.sh
 

--- a/kong/build-plugin.sh
+++ b/kong/build-plugin.sh
@@ -1,4 +1,4 @@
-LOGGER_VERSION=0.1.3
+LOGGER_VERSION=0.1.4
 
 luarocks make
 luarocks pack kong-plugin-kong-logger ${LOGGER_VERSION}

--- a/kong/docker-compose.yaml
+++ b/kong/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   kong-migrations:
-    image: kong:2.4.1-alpine-logger-0.1.3
+    image: kong:2.4.1-alpine-logger-0.1.4
     command: kong migrations bootstrap
     depends_on:
       db:
@@ -21,7 +21,7 @@ services:
     restart: on-failure
 
   kong:
-    image: kong:2.4.1-alpine-logger-0.1.3
+    image: kong:2.4.1-alpine-logger-0.1.4
     user: "${KONG_USER:-kong}"
     depends_on:
       db:

--- a/kong/kong-plugin-kong-logger-0.1.4-1.rockspec
+++ b/kong/kong-plugin-kong-logger-0.1.4-1.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-kong-logger"  
-version = "0.1.3-1"       
+version = "0.1.4-1"       
 
 -- Here we extract it from the package name.
 local pluginName = package:match("^kong%-plugin%-(.+)$")  -- "-logger"

--- a/kong/plugins/kong-logger/handler.lua
+++ b/kong/plugins/kong-logger/handler.lua
@@ -83,6 +83,14 @@ function LoggerHandler:log(conf)
 
     sanitize(dto.request)
     local asJson = cjson.encode(dto)
+    -- Due to limits of error logs, we filter the request body, under the assumption that the body is the cause of the large payload
+    local limit = conf.filter_body_on_limit
+    if limit ~= nil and string.len(asJson) > limit then
+      if dto.request ~= nil and dto.request.body ~= nil then
+        dto.request.body = nil
+        asJson = cjson.encode(dto)
+      end
+    end
     kong.log.err("[kong-logger]" .. asJson .. "[/kong-logger]")
   end
 

--- a/kong/plugins/kong-logger/schema.lua
+++ b/kong/plugins/kong-logger/schema.lua
@@ -22,6 +22,11 @@ return {
               },
             },
           },
+          { filter_body_on_limit = {
+            type = "number",
+            required = false,
+          },
+        }, 
         }
       }
     }


### PR DESCRIPTION
When the log entry reaches specified size (from config), filter the body from the request assuming its the one causing the blote.
Since kong logs are limited by size, this is important for systems with large request bodies

Closes #10 